### PR TITLE
A few other fixes

### DIFF
--- a/config/project_config_embeddable.cmake
+++ b/config/project_config_embeddable.cmake
@@ -2656,6 +2656,11 @@ macro (install_dev_helper_files)
   set (${PACKAGE_NAME}_LIBEXEC_DIR "${INSTALL_LIBEXEC_DIR}")
   set (${PACKAGE_NAME}_PY_LIB_DIR "${INSTALL_PY_LIB_DIR}")
   set (${PACKAGE_NAME}_CMAKE_DIR "${LIB_DEPENDENCY_EXPORT_PATH}")
+  # When the project is OpenTREP, OPENTREP_SAMPLE_DIR has
+  # already been defined before
+  if (NOT PROJECT_NAME STREQUAL "opentrep")
+    set (${PACKAGE_NAME}_SAMPLE_DIR "${INSTALL_SAMPLE_DIR}")
+  endif ()
   configure_package_config_file(
       ${PROJECT_NAME}-config.cmake.in
       ${PROJECT_NAME}-config.cmake
@@ -2665,17 +2670,13 @@ macro (install_dev_helper_files)
         ${PACKAGE_NAME}_BIN_DIR
         ${PACKAGE_NAME}_LIB_DIR
         ${PACKAGE_NAME}_LIBEXEC_DIR
+        ${PACKAGE_NAME}_SAMPLE_DIR
   )
   write_basic_package_version_file(
       ${PROJECT_NAME}-config-version.cmake
       VERSION ${PACKAGE_VERSION}
       COMPATIBILITY AnyNewerVersion
   )
-  # When the project is OpenTREP, OPENTREP_SAMPLE_DIR has
-  # already been defined before
-  if (NOT "${PROJECT_NAME}" STREQUAL "opentrep")
-    set (${PACKAGE_NAME}_SAMPLE_DIR "${INSTALL_SAMPLE_DIR}")
-  endif (NOT "${PROJECT_NAME}" STREQUAL "opentrep")
   if (NEED_PYTHON)
 	configure_file (${PROJECT_NAME}-config-python.cmake.in
 	  "${PROJECT_BINARY_DIR}/${PROJECT_NAME}-config-python.cmake" @ONLY)

--- a/stdair-config.cmake.in
+++ b/stdair-config.cmake.in
@@ -12,13 +12,13 @@
 
 # Tell the user project where to find the headers, libraries and sample files
 set (STDAIR_VERSION "@PACKAGE_VERSION@")
-set (STDAIR_BINARY_DIRS "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_BINDIR@")
-set (STDAIR_INCLUDE_DIRS "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@")
-set (STDAIR_LIBRARY_DIRS "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@")
-set (STDAIR_SAMPLE_DIR "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_DATADIR@/@PROJECT_NAME@/samples")
+set (STDAIR_BINARY_DIRS "@PACKAGE_STDAIR_BIN_DIR@")
+set (STDAIR_INCLUDE_DIRS "@PACKAGE_STDAIR_INCLUDE_DIRS@")
+set (STDAIR_LIBRARY_DIRS "@PACKAGE_STDAIR_LIB_DIR@")
+set (STDAIR_SAMPLE_DIR "@PACKAGE_STDAIR_SAMPLE_DIR@")
 
 # Our library dependencies (contains definitions for IMPORTED targets)
-include ("@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@/cmake/@PROJECT_NAME@/@PROJECT_NAME@-library-depends.cmake")
+include ("${CMAKE_CURRENT_LIST_DIR}/stdair-library-depends.cmake")
 
 # These are IMPORTED targets created by stdair-library-depends.cmake
 set (STDAIR_LIBRARIES stdairlib stdairuicllib)


### PR DESCRIPTION
- Add the ``${PACKAGE_NAME}_SAMPLE_DIR` to `PATH_VARS`
- Reverted the hard-coded `CMAKE_INSTALL_PREFIX`
- fix the `include` in stdair-config.cmake